### PR TITLE
IDP-573 - Fix nested activities

### DIFF
--- a/src/Workleap.Extensions.MediatR/RequestTracingBehavior.cs
+++ b/src/Workleap.Extensions.MediatR/RequestTracingBehavior.cs
@@ -8,27 +8,24 @@ internal sealed class RequestTracingBehavior<TRequest, TResponse> : IPipelineBeh
 {
     public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        var activity = TracingHelper.StartActivity();
+        using var activity = TracingHelper.StartActivity();
         return activity == null ? next() : HandleWithTracing(request, next, activity);
     }
 
     private static async Task<TResponse> HandleWithTracing(TRequest request, RequestHandlerDelegate<TResponse> next, Activity activity)
     {
-        using (activity)
-        {
-            activity.DisplayName = request.GetType().Name;
+        activity.DisplayName = request.GetType().Name;
 
-            try
-            {
-                var result = await next().ConfigureAwait(false);
-                TracingHelper.MarkAsSuccessful(activity);
-                return result;
-            }
-            catch (Exception ex)
-            {
-                TracingHelper.MarkAsFailed(activity, ex);
-                throw;
-            }
+        try
+        {
+            var result = await next().ConfigureAwait(false);
+            TracingHelper.MarkAsSuccessful(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            TracingHelper.MarkAsFailed(activity, ex);
+            throw;
         }
     }
 }


### PR DESCRIPTION
## Context
In terms of activity and tracing, we want to have each processed event to have the same parentId. That's not what was currently hapening. Currently every event would have the previous processed event as parent which would produce a trace similar to this:
```
|-- Parent Activity
|    |-- Handle request A
|        |-- Handle requestB 
```

But really what we want is something that looks like this:

```
|-- Parent Activity
|    |-- Handle request A
|    |-- Handle request B 
```

## What changed
There seemed to be some problem with the disposal of the activity which was making it be referenced beyond it's using block and into the next processing block. In order to remedy this, the following changes were made:

Moved using statement from HandleWithTracing to HandleAsync (This alone fixed the issue that could be clearly seen in Honeycomb for example)