### PR TITLE
Restored processors registration that was broken in MediatR 12.1.0+

### DIFF
--- a/src/Workleap.Extensions.MediatR.Analyzers.Tests/BaseAnalyzerTest.cs
+++ b/src/Workleap.Extensions.MediatR.Analyzers.Tests/BaseAnalyzerTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using MediatR;
+﻿using MediatR;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
@@ -34,12 +33,7 @@ global using MediatR;";
         this.TestState.Sources.Add(CSharp10GlobalUsings);
         this.TestState.Sources.Add(MediatRGlobalUsings);
 
-#if NETFRAMEWORK
-        this.TestState.ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard20
-            .WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "6.0.0")));
-#elif NET6_0
         this.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
-#endif
 
         // Reference "Microsoft.Extensions.DependencyInjection" assembly
         this.TestState.AdditionalReferences.Add(typeof(IServiceCollection).Assembly);

--- a/src/Workleap.Extensions.MediatR.Analyzers.Tests/Workleap.Extensions.MediatR.Analyzers.Tests.csproj
+++ b/src/Workleap.Extensions.MediatR.Analyzers.Tests/Workleap.Extensions.MediatR.Analyzers.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>true</SignAssembly>

--- a/src/Workleap.Extensions.MediatR.ApplicationInsights/Workleap.Extensions.MediatR.ApplicationInsights.csproj
+++ b/src/Workleap.Extensions.MediatR.ApplicationInsights/Workleap.Extensions.MediatR.ApplicationInsights.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.Extensions.MediatR.Tests/PreAndPostProcessorTests.cs
+++ b/src/Workleap.Extensions.MediatR.Tests/PreAndPostProcessorTests.cs
@@ -1,0 +1,180 @@
+﻿using GSoft.Extensions.Xunit;
+using MediatR;
+using MediatR.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Workleap.Extensions.MediatR.Tests;
+
+public sealed class PreAndPostProcessorTests : BaseUnitTest<PreAndPostProcessorTests.Fixture>
+{
+    public PreAndPostProcessorTests(Fixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture, testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task SendAsync_Executes_Automatically_Registered_Pre_And_Post_Processors()
+    {
+        var mediator = this.Services.GetRequiredService<IMediator>();
+        var state = this.Services.GetRequiredService<TestState>();
+
+        await mediator.SendAsync(new MyCommand(), CancellationToken.None);
+        await mediator.SendAsync(new MyQuery(), CancellationToken.None);
+
+        Assert.Equal(1, state.MyHandler_MyCommand_CallCount);
+        Assert.Equal(1, state.MyHandler_MyQuery_CallCount);
+
+        Assert.Equal(1, state.MyCommandPreProcessor_Pre_MyCommand_CallCount);
+        Assert.Equal(1, state.MyCommandPostProcessor_Post_MyCommand_CallCount);
+
+        Assert.Equal(1, state.MyFirstQueryPreAndPostProcessor_Pre_MyQuery_CallCount);
+        Assert.Equal(1, state.MyFirstQueryPreAndPostProcessor_Post_MyQuery_CallCount);
+
+        Assert.Equal(1, state.MySecondQueryPreAndPostProcessor_Pre_MyQuery_CallCount);
+        Assert.Equal(1, state.MySecondQueryPreAndPostProcessor_Post_MyQuery_CallCount);
+    }
+
+    public sealed class Fixture : BaseUnitFixture
+    {
+        public override IServiceCollection ConfigureServices(IServiceCollection services)
+        {
+            base.ConfigureServices(services);
+
+            services.AddSingleton<TestState>();
+            services.AddMediator(typeof(MediatorFixture).Assembly);
+
+            // Prevent activities from being emitted and interfere with other tests running in parallel
+            // Activity listeners are static and shared across all tests
+            for (var i = services.Count - 1; i >= 0; i--)
+            {
+                if (services[i].ImplementationType == typeof(RequestTracingBehavior<,>) || services[i].ImplementationType == typeof(StreamRequestTracingBehavior<,>))
+                {
+                    services.RemoveAt(i);
+                }
+            }
+
+            return services;
+        }
+    }
+
+    private sealed class TestState
+    {
+        public int MyHandler_MyCommand_CallCount { get; set; }
+
+        public int MyHandler_MyQuery_CallCount { get; set; }
+
+        public int MyCommandPreProcessor_Pre_MyCommand_CallCount { get; set; }
+
+        public int MyCommandPostProcessor_Post_MyCommand_CallCount { get; set; }
+
+        public int MyFirstQueryPreAndPostProcessor_Pre_MyQuery_CallCount { get; set; }
+
+        public int MyFirstQueryPreAndPostProcessor_Post_MyQuery_CallCount { get; set; }
+
+        public int MySecondQueryPreAndPostProcessor_Pre_MyQuery_CallCount { get; set; }
+
+        public int MySecondQueryPreAndPostProcessor_Post_MyQuery_CallCount { get; set; }
+    }
+
+    private sealed record MyCommand : IRequest;
+
+    private sealed record MyQuery : IRequest<bool>;
+
+    private sealed class MyHandler : IRequestHandler<MyCommand>, IRequestHandler<MyQuery, bool>
+    {
+        private readonly TestState _testState;
+
+        public MyHandler(TestState testState)
+        {
+            this._testState = testState;
+        }
+
+        public Task Handle(MyCommand request, CancellationToken cancellationToken)
+        {
+            this._testState.MyHandler_MyCommand_CallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> Handle(MyQuery request, CancellationToken cancellationToken)
+        {
+            this._testState.MyHandler_MyQuery_CallCount++;
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class MyCommandPreProcessor : IRequestPreProcessor<MyCommand>
+    {
+        private readonly TestState _testState;
+
+        public MyCommandPreProcessor(TestState testState)
+        {
+            this._testState = testState;
+        }
+
+        public Task Process(MyCommand request, CancellationToken cancellationToken)
+        {
+            this._testState.MyCommandPreProcessor_Pre_MyCommand_CallCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MyCommandPostProcessor : IRequestPostProcessor<MyCommand, Unit>
+    {
+        private readonly TestState _testState;
+
+        public MyCommandPostProcessor(TestState testState)
+        {
+            this._testState = testState;
+        }
+
+        public Task Process(MyCommand request, Unit response, CancellationToken cancellationToken)
+        {
+            this._testState.MyCommandPostProcessor_Post_MyCommand_CallCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MyFirstQueryPreAndPostProcessor : IRequestPreProcessor<MyQuery>, IRequestPostProcessor<MyQuery, bool>
+    {
+        private readonly TestState _testState;
+
+        public MyFirstQueryPreAndPostProcessor(TestState testState)
+        {
+            this._testState = testState;
+        }
+
+        public Task Process(MyQuery request, CancellationToken cancellationToken)
+        {
+            this._testState.MyFirstQueryPreAndPostProcessor_Pre_MyQuery_CallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task Process(MyQuery request, bool response, CancellationToken cancellationToken)
+        {
+            this._testState.MyFirstQueryPreAndPostProcessor_Post_MyQuery_CallCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MySecondQueryPreAndPostProcessor : IRequestPreProcessor<MyQuery>, IRequestPostProcessor<MyQuery, bool>
+    {
+        private readonly TestState _testState;
+
+        public MySecondQueryPreAndPostProcessor(TestState testState)
+        {
+            this._testState = testState;
+        }
+
+        public Task Process(MyQuery request, CancellationToken cancellationToken)
+        {
+            this._testState.MySecondQueryPreAndPostProcessor_Pre_MyQuery_CallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task Process(MyQuery request, bool response, CancellationToken cancellationToken)
+        {
+            this._testState.MySecondQueryPreAndPostProcessor_Post_MyQuery_CallCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Workleap.Extensions.MediatR/Workleap.Extensions.MediatR.csproj
+++ b/src/Workleap.Extensions.MediatR/Workleap.Extensions.MediatR.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description of changes

### Context

We planed to leverage MediatR pre and post processors to execute arbitrary code before and after requests are executed.
These processors used to be automatically registered. Developers didn't have to manually register them in the DI services.

In MediatR 12.1.0, the automatic registration was removed, and devs were forced to manually register them in the DI services.
In MediatR 12.2.0, the automatic registration was supposed to be brought back under an option that must be set to true (opt-in), but it's bugged.

More details in this opened PR: https://github.com/jbogard/MediatR/pull/989#issuecomment-1883574379

### Changes

* Wrote a "hack" that calls the MediatR internal code to execute the pre/post registration as before. Basically has the same effect than the opened PR mentioned above.
* Added tests to ensure that we always automatically register pre/post processors and the corresponding behavior.

## Breaking changes
Now that we upgraded to [MediatR 2.2.0](https://www.nuget.org/packages/MediatR/12.2.0), there are a few side-effects:
*  [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/) was upgraded from 6.0.0 to **8.0.0**
* [Same thing for ](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/) was upgraded from 6.0.0 to **8.0.0**

There's nothing we can do about that. There was no need for MediatR to do these upgrades. Usually third-parties dependencies like that are kept to a minimum version.

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

~- [ ] Updated the documentation of the project to reflect the changes~
- [x] Added new tests that cover the code changes
